### PR TITLE
FP-499: Include body of the message that failed for context

### DIFF
--- a/mixpanel.go
+++ b/mixpanel.go
@@ -262,7 +262,7 @@ func (m *mixpanel) sendImport(params interface{}, autoGeolocate bool) error {
 
 	// TODO(joey): If some records in the batch failed, return them so they can be retried.
 	if jsonBody.Status != "OK" {
-		errMsg := fmt.Sprintf("error=%s; status=%s; httpCode=%d", jsonBody.Error, jsonBody.Status, resp.StatusCode)
+		errMsg := fmt.Sprintf("error=%s; status=%s; httpCode=%d, body=%s", jsonBody.Error, jsonBody.Status, resp.StatusCode, string(body))
 		return wrapErr(&ErrTrackFailed{Message: errMsg})
 	}
 


### PR DESCRIPTION
Joey and I were pairing on an issue importing data into mixpanel where we see errors indicating some event data was invalid, but we can't see what would have been invalid. This change includes the message body in the error message so that we can better diagnose the problem.

Some thoughts:

- The body may be rather large, so naively printing the whole thing may be a bad idea -- feedback on this would be helpful
- It may still be unclear why a given event is invalid after we make this change