### PR TITLE
use golang context for cancellation

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,6 +1,9 @@
 package mixpanel
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 func ExampleNew() {
 	New("mytoken", "")
@@ -13,7 +16,7 @@ func ExampleNewWithSecret() {
 func ExampleMixpanel() {
 	client := New("mytoken", "")
 
-	client.Track("1", "Sign Up", &Event{
+	client.Track(context.TODO(), "1", "Sign Up", &Event{
 		Properties: map[string]interface{}{
 			"from": "email",
 		},
@@ -23,7 +26,7 @@ func ExampleMixpanel() {
 func ExamplePeople() {
 	client := NewWithSecret("mytoken", "myapisecret", "")
 
-	client.UpdateUser("1", &Update{
+	client.UpdateUser(context.TODO(), "1", &Update{
 		Operation: "$set",
 		Properties: map[string]interface{}{
 			"$email":       "user@email.com",
@@ -33,14 +36,14 @@ func ExamplePeople() {
 		},
 	})
 
-	client.Track("1", "Sign Up", &Event{
+	client.Track(context.TODO(), "1", "Sign Up", &Event{
 		Properties: map[string]interface{}{
 			"from": "email",
 		},
 	})
 
 	importTimestamp := time.Now().Add(-5 * 24 * time.Hour)
-	client.Import("1", "Sign Up", &Event{
+	client.Import(context.TODO(), "1", "Sign Up", &Event{
 		Timestamp: &importTimestamp,
 		Properties: map[string]interface{}{
 			"subject": "topic",

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/freshapint-io/mixpanel
+module github.com/freshpaint-io/mixpanel
 
 go 1.19

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/freshapint-io/mixpanel
+
+go 1.19

--- a/mock.go
+++ b/mock.go
@@ -1,6 +1,7 @@
 package mixpanel
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -39,7 +40,7 @@ func (m *Mock) people(distinctId string) *MockPeople {
 	return p
 }
 
-func (m *Mock) Track(distinctId, eventName string, e *Event) error {
+func (m *Mock) Track(ctx context.Context, distinctId, eventName string, e *Event) error {
 	p := m.people(distinctId)
 	p.Events = append(p.Events, MockEvent{
 		Event: *e,
@@ -48,7 +49,7 @@ func (m *Mock) Track(distinctId, eventName string, e *Event) error {
 	return nil
 }
 
-func (m *Mock) Import(distinctId, eventName string, e *Event) error {
+func (m *Mock) Import(ctx context.Context, distinctId, eventName string, e *Event) error {
 	p := m.people(distinctId)
 	p.Events = append(p.Events, MockEvent{
 		Event: *e,
@@ -93,11 +94,11 @@ func (mp *MockPeople) String() string {
 	return str
 }
 
-func (m *Mock) Update(distinctId string, u *Update) error {
-	return m.UpdateUser(distinctId, u)
+func (m *Mock) Update(ctx context.Context, distinctId string, u *Update) error {
+	return m.UpdateUser(ctx, distinctId, u)
 }
 
-func (m *Mock) UpdateUser(distinctId string, u *Update) error {
+func (m *Mock) UpdateUser(ctx context.Context, distinctId string, u *Update) error {
 	p := m.people(distinctId)
 
 	if u.IP != "" {
@@ -119,15 +120,15 @@ func (m *Mock) UpdateUser(distinctId string, u *Update) error {
 	return nil
 }
 
-func (m *Mock) UpdateGroup(groupKey, groupUser string, u *Update) error {
+func (m *Mock) UpdateGroup(ctx context.Context, groupKey, groupUser string, u *Update) error {
 	return nil
 }
 
-func (m *Mock) Alias(distinctId, newId string) error {
+func (m *Mock) Alias(ctx context.Context, distinctId, newId string) error {
 	return nil
 }
 
-func (m *Mock) ImportBatch(events []*TrackEvent) error {
+func (m *Mock) ImportBatch(ctx context.Context, events []*TrackEvent) error {
 	return nil
 }
 

--- a/mock_test.go
+++ b/mock_test.go
@@ -1,6 +1,7 @@
 package mixpanel
 
 import (
+	"context"
 	"fmt"
 	"time"
 )
@@ -12,7 +13,7 @@ func ExampleMock() {
 
 	t, _ := time.Parse(time.RFC3339, "2016-03-03T15:17:53+01:00")
 
-	client.Update("1", &Update{
+	client.Update(context.TODO(), "1", &Update{
 		Operation: "$set",
 		Timestamp: &t,
 		IP:        "127.0.0.1",
@@ -21,15 +22,15 @@ func ExampleMock() {
 		},
 	})
 
-	client.Track("1", "Sign Up", &Event{
+	client.Track(context.TODO(), "1", "Sign Up", &Event{
 		IP: "1.2.3.4",
 		Properties: map[string]interface{}{
 			"from": "email",
 		},
 	})
 
-	client.Import("1", "Sign Up", &Event{
-		IP: "1.2.3.4",
+	client.Import(context.TODO(), "1", "Sign Up", &Event{
+		IP:        "1.2.3.4",
 		Timestamp: &t,
 		Properties: map[string]interface{}{
 			"imported": true,


### PR DESCRIPTION
Hacked in golang context so we can reliably cancel / set timeouts on the requests. Also, I fixed the unit tests, which appeared to be inconsistent with previous changes.

Note: I did change the interface and this project is public, so I'm not sure if that's a concern. If it is, let me know, and I'll create new methods so the external API is non-breaking.