### PR TITLE
add unwrap for mixpanel error

### DIFF
--- a/mixpanel.go
+++ b/mixpanel.go
@@ -26,6 +26,14 @@ func (err *MixpanelError) Error() string {
 	return "mixpanel: " + err.Err.Error()
 }
 
+func (err *MixpanelError) Unwrap() error {
+	if err == nil {
+		return nil
+	}
+
+	return err.Err
+}
+
 type ErrTrackFailed struct {
 	Message string
 }

--- a/mixpanel_test.go
+++ b/mixpanel_test.go
@@ -3,6 +3,7 @@ package mixpanel
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -203,4 +204,13 @@ func TestError(t *testing.T) {
 	assertErrTrackFailed(client.Update(context.TODO(), "1", &Update{}))
 	assertErrTrackFailed(client.Track(context.TODO(), "1", "name", &Event{}))
 	assertErrTrackFailed(client.Import(context.TODO(), "1", "name", &Event{}))
+}
+
+func TestUnwrapCompatible(t *testing.T) {
+	mErr := &MixpanelError{Err: context.DeadlineExceeded}
+	err := error(mErr)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Error("not compatible with unwrap")
+	}
 }


### PR DESCRIPTION
Add unwrapping to mixpanel errors so we can use errors.Is/As to match underlying errors, for example, context.DeadlineExceeded. 