### PR TITLE
FP-658: leak error bodies to caller

### DIFF
--- a/mixpanel.go
+++ b/mixpanel.go
@@ -37,7 +37,7 @@ func (err *MixpanelError) Unwrap() error {
 type ErrTrackFailed struct {
 	Message  string
 	Body     []byte
-	HTTPCode *int
+	HTTPCode int
 }
 
 func (err *ErrTrackFailed) Error() string {
@@ -326,7 +326,7 @@ func (m *mixpanel) send(ctx context.Context, eventType string, params interface{
 
 	if jsonBody.Status != 1 {
 		errMsg := fmt.Sprintf("error=%s; status=%d; httpCode=%d", jsonBody.Error, jsonBody.Status, resp.StatusCode)
-		return wrapErr(&ErrTrackFailed{Message: errMsg})
+		return wrapErr(&ErrTrackFailed{Message: errMsg, HTTPCode: resp.StatusCode, Body: body})
 	}
 
 	return nil

--- a/mixpanel.go
+++ b/mixpanel.go
@@ -26,6 +26,14 @@ func (err *MixpanelError) Error() string {
 	return "mixpanel: " + err.Err.Error()
 }
 
+func (err *MixpanelError) Unwrap() error {
+	if err == nil {
+		return nil
+	}
+
+	return err.Err
+}
+
 type ErrTrackFailed struct {
 	Message string
 }

--- a/mixpanel.go
+++ b/mixpanel.go
@@ -277,7 +277,7 @@ func (m *mixpanel) sendImport(ctx context.Context, params interface{}, autoGeolo
 	// TODO(joey): If some records in the batch failed, return them so they can be retried.
 	if jsonBody.Status != "OK" {
 		errMsg := fmt.Sprintf("error=%s; status=%s; httpCode=%d, body=%s", jsonBody.Error, jsonBody.Status, resp.StatusCode, string(body))
-		return wrapErr(&ErrTrackFailed{Message: errMsg, HTTPCode: &resp.StatusCode, Body: body})
+		return wrapErr(&ErrTrackFailed{Message: errMsg, HTTPCode: resp.StatusCode, Body: body})
 	}
 
 	return nil

--- a/mixpanel.go
+++ b/mixpanel.go
@@ -35,7 +35,9 @@ func (err *MixpanelError) Unwrap() error {
 }
 
 type ErrTrackFailed struct {
-	Message string
+	Message  string
+	Body     []byte
+	HTTPCode *int
 }
 
 func (err *ErrTrackFailed) Error() string {
@@ -275,7 +277,7 @@ func (m *mixpanel) sendImport(ctx context.Context, params interface{}, autoGeolo
 	// TODO(joey): If some records in the batch failed, return them so they can be retried.
 	if jsonBody.Status != "OK" {
 		errMsg := fmt.Sprintf("error=%s; status=%s; httpCode=%d, body=%s", jsonBody.Error, jsonBody.Status, resp.StatusCode, string(body))
-		return wrapErr(&ErrTrackFailed{Message: errMsg})
+		return wrapErr(&ErrTrackFailed{Message: errMsg, HTTPCode: &resp.StatusCode, Body: body})
 	}
 
 	return nil

--- a/mixpanel_test.go
+++ b/mixpanel_test.go
@@ -3,6 +3,7 @@ package mixpanel
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -203,4 +204,13 @@ func TestError(t *testing.T) {
 	assertErrTrackFailed(client.Update(context.TODO(), "1", &Update{}))
 	assertErrTrackFailed(client.Track(context.TODO(), "1", "name", &Event{}))
 	assertErrTrackFailed(client.Import(context.TODO(), "1", "name", &Event{}))
+}
+
+func TestUnwrapCompatible(t *testing.T) {
+	mErr := &MixpanelError{Err: context.DeadlineExceeded}
+	err := error(mErr)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Error("not compatible with unwrap")
+	}
 }


### PR DESCRIPTION
Hack: leak the body / http status code in the track failed error so we can parse specific results in the upstream code.